### PR TITLE
Fix problems due to recent changes in pandas and yfinance.

### DIFF
--- a/RRGIndicator.py
+++ b/RRGIndicator.py
@@ -363,7 +363,7 @@ def animate(i):
 
     return scatter_plots + line_plots + annotations
 
-def close():
+def close(_ = None):
     sys.exit(0)
 
 # call the animator. blit=True means only re-draw the parts that have changed.


### PR DESCRIPTION
1. Fix for pandas changes requiring use of .iloc[] and .loc[]
2. Fix for yfinance changes involving the shape of returned dataframes and elimination of the `Adj Close` field.
3. Remove some duplicated code.
4. Added some typing info.
5. Allow resizing the tk window so all of the tickers are visible.
6. Suppress the yfinance progress message.
7. Add some protection when a symbol doesn't exist (such as `AUT.PA` apparently)
8. Exit cleanly when the user closes the tk window, presses escape, or hits ^C in the python window.

This PR should fix issues 3 and 4, and possibly also 1.